### PR TITLE
revert to pin 1, as pin 21 is LED+

### DIFF
--- a/Bar_1.91_Clockwise/Bar_1.91_Clockwise.ino
+++ b/Bar_1.91_Clockwise/Bar_1.91_Clockwise.ino
@@ -267,7 +267,7 @@ void setup() {
   motor[1].initialize(25, 26);
   motor[2].initialize(27, 14);
   motor[3].initialize(13, 23);
-  motor[4].initialize(21, 3);
+  motor[4].initialize(1, 3);
   motor[5].initialize(19, 18);
   motor[6].initialize( 5, 17);
   motor[7].initialize(16, 4);


### PR DESCRIPTION
Due the change to pin 21, PUMP5 was always on
changed back to pin 1 make it usable again